### PR TITLE
[#31] Reveal 생성, 수정, 목록 및 특정 조회 코드

### DIFF
--- a/src/main/java/reborn/backend/global/api_payload/ErrorCode.java
+++ b/src/main/java/reborn/backend/global/api_payload/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode implements BaseCode {
     // Rediary
     REDIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "REDIARY_4041", "존재하지 않는 감정 일기입니다."),
 
+    // Reveal
+    REVEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "REVEAL_4041", "존재하지 않는 나의 감정 들여다보기입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/reborn/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/reborn/backend/global/api_payload/SuccessCode.java
@@ -54,6 +54,11 @@ public enum SuccessCode implements BaseCode {
     REDIARY_DELETED(HttpStatus.OK, "REDIARY_2004", "감정 일기 삭제가 완료되었습니다."),
     REDIARY_TODAY_WRITTEN_CHECKD(HttpStatus.OK, "REDIARY_2005", "당일 감정일기 작성한 여부 알려줍니다."),
 
+    // Reveal
+    REVEAL_CREATED(HttpStatus.CREATED, "REVEAL_2011", "나의 감정 들여다보기 생성이 완료되었습니다."),
+    REVEAL_LIST_VIEW_SUCCESS(HttpStatus.OK, "REVEAL_2001", "나의 감정 들여다보기 목록 조회가 완료되었습니다."),
+    REVEAL_DETAIL_VIEW_SUCCESS(HttpStatus.OK, "REVEAL_2002", "나의 감정 들여다보기 조회가 완료되었습니다."),
+    REVEAL_UPDATED(HttpStatus.OK, "REVEAL_2003", "나의 감정 들여다보기 수정이 완료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/reborn/backend/rediary/controller/RediaryController.java
+++ b/src/main/java/reborn/backend/rediary/controller/RediaryController.java
@@ -86,7 +86,7 @@ public class RediaryController {
     // 특정 rediary 가져오기
     @Operation(summary = "특정 감정 일기 조회 메서드", description = "특정 감정 일기를 조회하는 메서드입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REDIARY_2002", description = "감정 읽기 조회가 완료되었습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REDIARY_2002", description = "감정 일기 조회가 완료되었습니다.")
     })
     @GetMapping("/{id}")
     public ApiResponse<DetailRediaryDto> getDetailRediary(

--- a/src/main/java/reborn/backend/reveal/controller/RevealController.java
+++ b/src/main/java/reborn/backend/reveal/controller/RevealController.java
@@ -1,0 +1,108 @@
+package reborn.backend.reveal.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reborn.backend.global.api_payload.ApiResponse;
+import reborn.backend.global.api_payload.SuccessCode;
+import reborn.backend.reveal.converter.RevealConverter;
+import reborn.backend.reveal.domain.Reveal;
+import reborn.backend.reveal.dto.RevealRequestDto.DetailRevealReqDto;
+import reborn.backend.reveal.dto.RevealRequestDto.RevealReqDto;
+import reborn.backend.reveal.dto.RevealResponseDto.DetailRevealDto;
+import reborn.backend.reveal.service.RevealService;
+import reborn.backend.user.domain.User;
+import reborn.backend.user.jwt.CustomUserDetails;
+import reborn.backend.user.service.UserService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "나의 감정 들여다보기", description = "나의 감정 들여다보기 관련 api 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reveal")
+public class RevealController {
+
+    private final UserService userService;
+    private final RevealService revealService;
+
+    // reveal 만들기
+    @Operation(summary = "나의 감정 들여다보기 만들기 메서드", description = "나의 감정 들여다보기 만드는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVEAL_2011", description = "나의 감정 들여다보기 생성이 완료되었습니다.")
+    })
+    @PostMapping("/create")
+    public ApiResponse<Double> create(
+            @RequestBody RevealReqDto revealReqDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+        Reveal reveal = revealService.createReveal(revealReqDto, user);
+
+        double emotionPercentage = revealService.calculateEmotionPercentage(reveal.getRevealId());
+
+        return ApiResponse.onSuccess(SuccessCode.REVEAL_CREATED, emotionPercentage);
+    }
+
+    // 모든 reveal 가져오기
+    @Operation(summary = "나의 감정 들여다보기 조회 메서드", description = "나의 감정 들여다보기 목록을 조회하는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVEAL_2001", description = " 나의 감정 들여다보기 목록 조회가 완료되었습니다.")
+    })
+    @GetMapping("/list")
+    public ApiResponse<List<DetailRevealDto>> getAllReveal(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+
+        List<Reveal> reveals = revealService.findAllByUserSortedByCreatedAt(user);
+        List<DetailRevealDto> revealDtos = reveals.stream()
+                .map(RevealConverter::toDetailRevealDto)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(SuccessCode.REVEAL_LIST_VIEW_SUCCESS, revealDtos);
+    }
+
+    // 특정 reveal 가져오기
+    @Operation(summary = "특정 나의 감정 들여다보기 조회 메서드", description = "특정 나의 감정 들여다보기를 조회하는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVEAL_2002", description = " 나의 감정 들여다보기 조회가 완료되었습니다.")
+    })
+    @GetMapping("/{id}")
+    public ApiResponse<DetailRevealDto> getDetailReveal(
+            @PathVariable(name = "id") Long id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+
+        Reveal reveal = revealService.findById(id);
+        DetailRevealDto detailRevealDto = RevealConverter.toDetailRevealDto(reveal);
+
+        return ApiResponse.onSuccess(SuccessCode.REVEAL_DETAIL_VIEW_SUCCESS, detailRevealDto);
+    }
+
+
+    // reveal 수정하기
+    @Operation(summary = "나의 감정 들여다보기 수정 메서드", description = "나의 감정 들여다보기 수정하는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REVEAL_2003", description = "나의 감정 들여다보기 수정이 완료되었습니다.")
+    })
+    @PostMapping("/update/{id}")
+    public ApiResponse<Double> update(
+            @PathVariable(name = "id") Long id,
+            @RequestBody DetailRevealReqDto detailRevealReqDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+
+        Reveal reveal = revealService.updateReveal(id, detailRevealReqDto);
+
+        double emotionPercentage = revealService.calculateEmotionPercentage(reveal.getRevealId());
+
+        return ApiResponse.onSuccess(SuccessCode.REVEAL_UPDATED, emotionPercentage);
+    }
+}

--- a/src/main/java/reborn/backend/reveal/converter/RevealConverter.java
+++ b/src/main/java/reborn/backend/reveal/converter/RevealConverter.java
@@ -1,0 +1,34 @@
+package reborn.backend.reveal.converter;
+
+import lombok.NoArgsConstructor;
+import reborn.backend.global.entity.PickEmotion;
+import reborn.backend.global.entity.ResultEmotion;
+import reborn.backend.reveal.domain.Reveal;
+import reborn.backend.reveal.dto.RevealRequestDto.RevealReqDto;
+import reborn.backend.reveal.dto.RevealResponseDto.DetailRevealDto;
+import reborn.backend.user.domain.User;
+
+@NoArgsConstructor
+public class RevealConverter {
+
+    public static Reveal toReveal(RevealReqDto reveal, User user) {
+        return Reveal.builder()
+                .revealWriter(user.getUsername())
+                .revealContents(reveal.getRevealContents())
+                .revealCreatedAt(reveal.getRevealCreatedAt())
+                .pickEmotion(PickEmotion.valueOf(reveal.getPickEmotion()))
+                .resultEmotion(ResultEmotion.valueOf(reveal.getResultEmotion()))
+                .build();
+    }
+
+    public static DetailRevealDto toDetailRevealDto(Reveal remind) {
+        return DetailRevealDto.builder()
+                .revealId(remind.getRevealId())
+                .revealWriter(remind.getRevealWriter())
+                .revealContents(remind.getRevealContents())
+                .pickEmotion(String.valueOf(remind.getPickEmotion()))
+                .resultEmotion(String.valueOf(remind.getResultEmotion()))
+                .revealCreatedAt(remind.getRevealCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/reborn/backend/reveal/domain/Reveal.java
+++ b/src/main/java/reborn/backend/reveal/domain/Reveal.java
@@ -1,0 +1,36 @@
+package reborn.backend.reveal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import reborn.backend.global.entity.BaseEntity;
+import reborn.backend.global.entity.PickEmotion;
+import reborn.backend.global.entity.ResultEmotion;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reveal extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long revealId;
+
+    @Column(length = 20, nullable = false)
+    private String revealWriter;
+
+    @Column(nullable = false)
+    private Integer revealCreatedAt;
+
+    @Column(nullable = false)
+    private String revealContents;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PickEmotion pickEmotion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ResultEmotion resultEmotion;
+}

--- a/src/main/java/reborn/backend/reveal/dto/RevealRequestDto.java
+++ b/src/main/java/reborn/backend/reveal/dto/RevealRequestDto.java
@@ -1,0 +1,50 @@
+package reborn.backend.reveal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@NoArgsConstructor
+public class RevealRequestDto {
+
+    @Schema(description = "RevealReqDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RevealReqDto {
+
+        @Schema(description = "나의 감정 들여다보기 내용")
+        private String revealContents;
+
+        @Schema(description = "나의 감정 들여다보기 작성일")
+        private Integer revealCreatedAt;
+
+        @Schema(description = "선택한 감정 상태(SUNNY, CLOUDY, RAINY)")
+        private String pickEmotion; // 감정 상태를 추가합니다.
+
+        @Schema(description = "결과로 나온 감정 상태(RED, YELLOW, BLUE)")
+        private String resultEmotion;
+    }
+
+    @Schema(description = "DetailRevealReqDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DetailRevealReqDto {
+        @Schema(description = "나의 감정 들여다보기 id")
+        private Long revealId;
+
+        @Schema(description = "나의 감정 들여다보기 내용")
+        private String revealContents;
+
+        @Schema(description = "나의 감정 들여다보기 작성일")
+        private Integer revealCreatedAt;
+
+        @Schema(description = "선택한 감정 상태(SUNNY, CLOUDY, RAINY)")
+        private String pickEmotion; // 감정 상태를 추가합니다.
+
+        @Schema(description = "결과로 나온 감정 상태(RED, YELLOW, BLUE)")
+        private String resultEmotion;
+    }
+}

--- a/src/main/java/reborn/backend/reveal/dto/RevealResponseDto.java
+++ b/src/main/java/reborn/backend/reveal/dto/RevealResponseDto.java
@@ -1,0 +1,46 @@
+package reborn.backend.reveal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+public class RevealResponseDto {
+
+    @Schema(description = "RevealListDto")
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RevealListResDto{
+        @Schema(description = "나의 감정 들여다보기 리스트")
+        private List<DetailRevealDto> remindList;
+    }
+
+    @Schema(description = "DetailRevealDto")
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailRevealDto {
+
+        @Schema(description = "나의 감정 들여다보기 id")
+        private Long revealId;
+
+        @Schema(description = "나의 감정 들여다보기 작성자")
+        private String revealWriter;
+
+        @Schema(description = "나의 감정 들여다보기 내용")
+        private String revealContents;
+
+        @Schema(description = "나의 감정 들여다보기 작성일")
+        private Integer revealCreatedAt;
+
+        @Schema(description = "선택한 감정 상태(SUNNY, CLOUDY, RAINY)")
+        private String pickEmotion; // 감정 상태를 추가합니다.
+
+        @Schema(description = "결과로 나온 감정 상태(RED, YELLOW, BLUE)")
+        private String resultEmotion;
+    }
+}

--- a/src/main/java/reborn/backend/reveal/repository/RevealRepository.java
+++ b/src/main/java/reborn/backend/reveal/repository/RevealRepository.java
@@ -1,0 +1,17 @@
+package reborn.backend.reveal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import reborn.backend.reveal.domain.Reveal;
+
+import java.util.List;
+
+@Repository
+public interface RevealRepository extends JpaRepository<Reveal, Long>, JpaSpecificationExecutor<Reveal> {
+
+    List<Reveal> findAllByRevealWriterOrderByCreatedAt(String userName);
+
+    List<Reveal> findAllByRevealCreatedAt(Integer date);
+
+}

--- a/src/main/java/reborn/backend/reveal/service/RevealService.java
+++ b/src/main/java/reborn/backend/reveal/service/RevealService.java
@@ -1,0 +1,84 @@
+package reborn.backend.reveal.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reborn.backend.global.api_payload.ErrorCode;
+import reborn.backend.global.entity.PickEmotion;
+import reborn.backend.global.entity.ResultEmotion;
+import reborn.backend.global.exception.GeneralException;
+import reborn.backend.reveal.converter.RevealConverter;
+import reborn.backend.reveal.domain.Reveal;
+import reborn.backend.reveal.dto.RevealRequestDto.DetailRevealReqDto;
+import reborn.backend.reveal.dto.RevealRequestDto.RevealReqDto;
+import reborn.backend.reveal.repository.RevealRepository;
+import reborn.backend.user.domain.User;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RevealService {
+
+    private final RevealRepository revealRepository;
+
+    @Transactional
+    public Reveal createReveal(RevealReqDto revealReqDto, User user) {
+        Reveal reveal = RevealConverter.toReveal(revealReqDto, user);
+
+        revealRepository.save(reveal);
+
+        return reveal;
+    }
+
+    @Transactional
+    public Reveal updateReveal(Long id, DetailRevealReqDto detailRevealReqDto) {
+        Reveal reveal = revealRepository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.REVEAL_NOT_FOUND));
+
+        reveal.setRevealContents(detailRevealReqDto.getRevealContents());
+        reveal.setRevealCreatedAt(detailRevealReqDto.getRevealCreatedAt());
+        reveal.setPickEmotion(PickEmotion.valueOf(detailRevealReqDto.getPickEmotion()));
+        reveal.setResultEmotion(ResultEmotion.valueOf(detailRevealReqDto.getResultEmotion()));
+
+        revealRepository.save(reveal);
+
+        return reveal;
+    }
+
+    @Transactional
+    public List<Reveal> findAllByUserSortedByCreatedAt(User user) {
+        return revealRepository.findAllByRevealWriterOrderByCreatedAt(user.getUsername());
+    }
+
+    @Transactional
+    public Reveal findById(Long id){
+        return revealRepository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.REVEAL_NOT_FOUND));
+    }
+
+    @Transactional
+    public List<Reveal> findAllByCreatedAt(Long id) {
+        Reveal remind = revealRepository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.REVEAL_NOT_FOUND));
+        return revealRepository.findAllByRevealCreatedAt(remind.getRevealCreatedAt());
+    }
+
+    @Transactional
+    public Double calculateEmotionPercentage(Long id) {
+        Reveal reveal = revealRepository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.REVEAL_NOT_FOUND));
+
+        List<Reveal> allRevealsByCreatedAt = findAllByCreatedAt(id);
+
+        long countSelectedEmotion = allRevealsByCreatedAt.stream()
+                .filter(r -> r.getResultEmotion() == reveal.getResultEmotion())
+                .count();
+
+        long totalTodayReveals = allRevealsByCreatedAt.size();
+
+        return (double) countSelectedEmotion / totalTodayReveals * 100.0;
+    }
+}


### PR DESCRIPTION
PR 타입
파일 추가

반영 브랜치
feature/31 -> develop

변경 사항
REVEAL 만들기
REVEAL 목록 조회
특정 REVEAL 조회
REVEAL 수정
삭제

테스트 결과
![image](https://github.com/VeryyyGood/Reborn-Back/assets/127291567/788c37e4-e046-4efb-8378-49d43ccea029)
생성 및 퍼센티지 반환

![image](https://github.com/VeryyyGood/Reborn-Back/assets/127291567/99c819cb-4000-4d91-9806-221eef97cedd)
rediaryCreatedAt으로 퍼센티지 반환을 확인

![image](https://github.com/VeryyyGood/Reborn-Back/assets/127291567/a0498d84-72b3-4a97-acb6-f6810e42ce99)
수정 및 퍼센티지 반환

![image](https://github.com/VeryyyGood/Reborn-Back/assets/127291567/3aae089f-0dff-4623-b63b-b765d340cb87)
list 조회
현재 이슈로는 rediaryCreatedAt이 아닌, BaseEntity에 있는 createdAt으로 정렬되서 발생하는 문제가 있는데, 이는 다른 날짜에 Reveal을 만들게 설정할 것이므로 보완하지 않아도 될 문제로 보임.

![image](https://github.com/VeryyyGood/Reborn-Back/assets/127291567/42d43bc9-f998-4d5b-8440-8a35fbfd3e51)
특정 Reveal 조회
